### PR TITLE
Survey Announcement & 'alt' fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@ Tim Welch will present Turf.js, a Javascript library for spatial analysis.  He'l
           ><img src="./assets/img/logos/slack.png" alt="Slack Logo"
         /></a>
         <a href="https://groups.google.com/g/pdx-osgeo"
-          ><img src="./assets/img/logos/google.png" alt="Twitter Logo"
+          ><img src="./assets/img/logos/google.png" alt="Google Logo"
         /></a>
         <a href="https://github.com/pdxosgeo/pdxosgeoweb"
           ><img src="./assets/img/logos/github.png" alt="Github Logo"

--- a/index.html
+++ b/index.html
@@ -278,7 +278,33 @@
         <p>©<a href="https://xkcd.com">xkcd, inc.</a></p>
       </div>
       <div class="main">
+        <!-- Community Survey -->
+        <h2>PDX OSGEO Community Survey</h2>
+        <p>
+          We want to hear from you! Please take a moment to fill out our community survey and help us improve our meetings and events.
+        </p>
+        <p>
+          <a href="https://forms.gle/rdpFdybZMSBjcPgb6" class="button">Take the Survey</a>
+        </p>
+        <p>The survey is live through October 5th, 2025. More details can be found on <a href="https://groups.google.com/g/pdx-osgeo"
+          >the mailing list</a>.</p>
+
         <!-- Upcoming Meeting -->
+        
+        <hr />
+        <!-- Past Meetings -->
+         
+        <h2
+          id="past-meetings"
+          style="
+            margin-top: 20px;
+            padding-top: 20px;
+            border-top: 1px solid #ddd;
+          "
+        >
+          Past Meetings
+        </h2>
+        <br />
         <h2>Sept. Meeting - Show & Tell!</h2>
         <p class="byline">
           Wednesday 9/17 6:30pm | Hot Lips Pizza @ the Natural
@@ -301,19 +327,6 @@
           alt="Natural Capital Center"
           width="100%"
         />
-        <hr />
-        <!-- Past Meetings -->
-        <h2
-          id="past-meetings"
-          style="
-            margin-top: 20px;
-            padding-top: 20px;
-            border-top: 1px solid #ddd;
-          "
-        >
-          Past Meetings
-        </h2>
-        <br />
         <h2>June Meeting - Ryan Burley</h2>
         <p class="byline">
           Wednesday 6/18 6:30pm | Hot Lips Pizza + ZOOM call @ the Natural


### PR DESCRIPTION
I want to announce the survey for anyone who is watching the website rather than the Mailing List (I dunno if that's anyone, but this was easy enough). I'll assume if anyone with permission to approve this PR likes it, that's enough of a 'vote' to okay it.

However, if the stance is "this feed is ONLY for meeting announcements" then I get that, too.